### PR TITLE
Zooming and panning

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,19 +15,29 @@
   let previewHeight: number
   let panX: number = 0
   let panY: number = 0
+  let zoom: number = 1
+  $: offsetX = (-previewWidth / 2) * zoom + panX
+  $: offsetY = (-previewHeight / 2) * zoom + panY
   $: viewBox = `
-    ${-previewWidth / 2 + panX}
-    ${-previewHeight / 2 + panY}
-    ${previewWidth}
-    ${previewHeight}`
+    ${offsetX}
+    ${offsetY}
+    ${previewWidth * zoom}
+    ${previewHeight * zoom}`
 
   let panning: boolean = false
   const startPan = () => (panning = true)
   const endPan = () => (panning = false)
   const movePan = (e: MouseEvent) => {
     if (panning) {
-      panX -= e.movementX
-      panY -= e.movementY
+      panX -= e.movementX * zoom
+      panY -= e.movementY * zoom
+    }
+  }
+
+  const wheelZoom = (e: WheelEvent) => {
+    zoom += e.deltaY / 1000
+    if (zoom < 0.2) {
+      zoom = 0.2
     }
   }
 
@@ -114,7 +124,13 @@
     </section>
   </div>
   <div id="preview" bind:clientWidth={previewWidth} bind:clientHeight={previewHeight}>
-    <svg {viewBox} on:mousedown={startPan} on:mouseup={endPan} on:mousemove={movePan}>
+    <svg
+      {viewBox}
+      on:mousedown={startPan}
+      on:mouseup={endPan}
+      on:mousemove={movePan}
+      on:wheel={wheelZoom}
+    >
       {#each $level.planets as planet}
         <path
           d="M {planet.orbit.x - planet.orbit.a} {-planet.orbit.y}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,10 +11,25 @@
   let selectedType: Selection = null
   let selectedIndex: number = 0 // Only meaningful if selectedType !== null
 
-  let svg: SVGSVGElement
-  $: viewBox = svg
-    ? `${-svg.clientWidth / 2} ${-svg.clientHeight / 2} ${svg.clientWidth} ${svg.clientHeight}`
-    : '0 0 100 100'
+  let previewWidth: number
+  let previewHeight: number
+  let panX: number = 0
+  let panY: number = 0
+  $: viewBox = `
+    ${-previewWidth / 2 + panX}
+    ${-previewHeight / 2 + panY}
+    ${previewWidth}
+    ${previewHeight}`
+
+  let panning: boolean = false
+  const startPan = () => (panning = true)
+  const endPan = () => (panning = false)
+  const movePan = (e: MouseEvent) => {
+    if (panning) {
+      panX -= e.movementX
+      panY -= e.movementY
+    }
+  }
 
   let intervalId: number | null = null
   let prevIntervalMillis: number = 0
@@ -98,8 +113,8 @@
       {/if}
     </section>
   </div>
-  <div id="preview">
-    <svg {viewBox} bind:this={svg}>
+  <div id="preview" bind:clientWidth={previewWidth} bind:clientHeight={previewHeight}>
+    <svg {viewBox} on:mousedown={startPan} on:mouseup={endPan} on:mousemove={movePan}>
       {#each $level.planets as planet}
         <path
           d="M {planet.orbit.x - planet.orbit.a} {-planet.orbit.y}


### PR DESCRIPTION
Add zooming (scroll wheel) and panning (click and drag) to the level editor. Added clientHeight/clientWidth bindings to the parent div because they are not valid on the svg directly. Zooming is centered at the center of the screen. Tried to have it where the mouse is but got stuck so this is good enough for now.

- [x] Add zooming
- [x] Add panning

This is essential if we want to be able to create large levels.