### PR TITLE
Map preview selection and deselection, highlighting

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,12 +25,17 @@
     ${previewHeight * zoom}`
 
   let panning: boolean = false
-  const startPan = () => (panning = true)
+  let panned: boolean = false
+  const startPan = () => {
+    panning = true
+    panned = false
+  }
   const endPan = () => (panning = false)
   const movePan = (e: MouseEvent) => {
     if (panning) {
       panX -= e.movementX * zoom
       panY -= e.movementY * zoom
+      panned = true
     }
   }
 
@@ -130,6 +135,9 @@
       on:mouseup={endPan}
       on:mousemove={movePan}
       on:wheel={wheelZoom}
+      on:click={() => {
+        if (!panned) selectedType = null
+      }}
     >
       {#each $level.planets as planet}
         <path
@@ -147,12 +155,21 @@
           fill="transparent"
         />
       {/each}
-      {#each $level.planets as planet}
+      {#each $level.planets as planet, i}
         <circle
+          class:selected={selectedType === 'Planet' && selectedIndex === i}
+          style:--playercolor={playerColor(planet.owner)}
           cx={cubicBezierX(planet.orbit, elapsedTime)}
           cy={-cubicBezierY(planet.orbit, elapsedTime)}
           r={planet.radius}
           fill={playerColor(planet.owner)}
+          on:click={(event) => {
+            if (!panned) {
+              selectedType = 'Planet'
+              selectedIndex = i
+              event.stopPropagation()
+            }
+          }}
         />
       {/each}
       {#each $level.planets as planet}
@@ -172,8 +189,22 @@
           />
         {/each}
       {/each}
-      {#each $level.suns as sun}
-        <circle cx={sun.x} cy={-sun.y} r={sun.radius} fill="yellow" />
+      {#each $level.suns as sun, i}
+        <circle
+          class:selected={selectedType === 'Sun' && selectedIndex === i}
+          style:--playercolor={'yellow'}
+          cx={sun.x}
+          cy={-sun.y}
+          r={sun.radius}
+          fill="yellow"
+          on:click={(event) => {
+            if (!panned) {
+              selectedType = 'Sun'
+              selectedIndex = i
+              event.stopPropagation()
+            }
+          }}
+        />
       {/each}
     </svg>
     <div>
@@ -217,6 +248,9 @@
     width: 100%;
     height: 100%;
     background: #141414;
+  }
+  svg .selected {
+    filter: drop-shadow(0px 0px 24px var(--playercolor));
   }
   h1 {
     padding: 1rem;

--- a/src/sample.json
+++ b/src/sample.json
@@ -4,7 +4,7 @@
       "owner": 1,
       "radius": 40,
       "moons": 3,
-      "spawndelay": 0.5,
+      "spawndelay": 3,
       "orbit": {
         "x": 0,
         "y": 0,
@@ -19,7 +19,7 @@
       "owner": 0,
       "radius": 20,
       "moons": 5,
-      "spawndelay": 0.5,
+      "spawndelay": 3,
       "orbit": {
         "x": 0,
         "y": 0,
@@ -34,7 +34,7 @@
       "owner": -1,
       "radius": 20,
       "moons": 0,
-      "spawndelay": 0.5,
+      "spawndelay": 3,
       "orbit": {
         "x": 200,
         "y": 100,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,7 +4,7 @@ export const templatePlanet = (): Planet => ({
   owner: -1,
   radius: 20,
   moons: 0,
-  spawndelay: 0.5,
+  spawndelay: 3,
   orbit: {
     x: 0,
     y: 0,
@@ -62,6 +62,6 @@ export const playerColor = (player: number) => {
     case 1:
       return 'red'
     default:
-      return 'lime'
+      return 'lightgray'
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/level-editor/',
-  plugins: [svelte()],
+  plugins: [
+    svelte({
+      onwarn: (warning, handler) => {
+        if (warning.code === 'a11y-click-events-have-key-events') return
+        handler(warning)
+      },
+    }),
+  ],
 })


### PR DESCRIPTION
Adds the ability to better see which planet/sun is currently selected in the map preview by giving it a shadow around it. Kind of hard to see with the blue player color though. Planets/sun are selectable directly from the map so you don't have to guess which one it is in the list of planets on the left. Can also deselect them by clicking anywhere else on the map. This is all compatible with panning and does not interfere with it.

- [x] Draw colored shadow around selected item on map preview
- [x] Click on planets/suns directly on map to select them
- [x] Deselect by clicking in empty space
- [x] Change color of neutral planets to lightgray
- [x] Adjust `spawndelay` (unused in game right now) to have default value of 3

This makes working with large maps with many planets much easier because you can select them by clicking on the map and it's obvious which one is being manipulated. In the future I might add functionality to adjust orbits/move things around directly on the map too.