### PR TITLE
Change player ID encoding, lower default planet speeds

### DIFF
--- a/src/lib/PlanetEditor.svelte
+++ b/src/lib/PlanetEditor.svelte
@@ -10,9 +10,9 @@
   <div class="control">
     <label for="planet-owner">Owner:</label>
     <select id="planet-owner" bind:value={$level.planets[index].owner}>
-      <option value={-1}>Neutral</option>
-      <option value={0}>Player 0</option>
+      <option value={0}>Neutral</option>
       <option value={1}>Player 1</option>
+      <option value={2}>Player 2</option>
     </select>
   </div>
   <div class="control">

--- a/src/sample.json
+++ b/src/sample.json
@@ -1,7 +1,7 @@
 {
   "planets": [
     {
-      "owner": 1,
+      "owner": 2,
       "radius": 40,
       "moons": 3,
       "spawndelay": 3,
@@ -10,13 +10,13 @@
         "y": 0,
         "a": 400,
         "b": 200,
-        "speed": 0.1,
+        "speed": 0.04,
         "direction": "clockwise",
         "progress": 0
       }
     },
     {
-      "owner": 0,
+      "owner": 1,
       "radius": 20,
       "moons": 5,
       "spawndelay": 3,
@@ -25,13 +25,13 @@
         "y": 0,
         "a": 150,
         "b": 150,
-        "speed": 0.05,
+        "speed": 0.02,
         "direction": "clockwise",
         "progress": 0
       }
     },
     {
-      "owner": -1,
+      "owner": 0,
       "radius": 20,
       "moons": 0,
       "spawndelay": 3,
@@ -40,7 +40,7 @@
         "y": 100,
         "a": 100,
         "b": 100,
-        "speed": 0.2,
+        "speed": 0.08,
         "direction": "clockwise",
         "progress": 0
       }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,7 +1,7 @@
 import type { Orbit, Planet, Sun } from '../types'
 
 export const templatePlanet = (): Planet => ({
-  owner: -1,
+  owner: 0,
   radius: 20,
   moons: 0,
   spawndelay: 3,
@@ -10,7 +10,7 @@ export const templatePlanet = (): Planet => ({
     y: 0,
     a: 100,
     b: 100,
-    speed: 0.1,
+    speed: 0.04,
     direction: 'clockwise',
     progress: 0,
   },
@@ -58,10 +58,12 @@ export const cubicBezierY = (orbit: Orbit, time: number) => {
 export const playerColor = (player: number) => {
   switch (player) {
     case 0:
-      return 'blue'
+      return 'lightgray'
     case 1:
+      return 'blue'
+    case 2:
       return 'red'
     default:
-      return 'lightgray'
+      return 'black'
   }
 }


### PR DESCRIPTION
Changes neutral planets to be owned by player 0 instead of player -1, with the colors and sample level updated accordingly. Initial speed of new planets has also been reduced to 0.04 from 0.1.